### PR TITLE
fix(school.program): ensure totals are recomputed on changes

### DIFF
--- a/school_management/models/program.py
+++ b/school_management/models/program.py
@@ -74,7 +74,7 @@ class Program(models.Model):
         "school.open.form.mixin",
     ]
 
-    @api.depends("bloc_ids.total_hours", "bloc_ids.total_credits")
+    @api.depends("bloc_ids", "bloc_ids.total_hours", "bloc_ids.total_credits")
     def _compute_courses_total(self):
         for rec in self:
             total_hours = 0.0
@@ -210,6 +210,7 @@ class Bloc(models.Model):
     _order = "program_id,sequence"
 
     @api.depends(
+        "course_group_ids",
         "course_group_ids.total_hours",
         "course_group_ids.total_credits",
         "course_group_ids.total_weight",
@@ -434,7 +435,9 @@ class CourseGroup(models.Model):
 
     weight = fields.Integer(string="Weight")
 
-    @api.depends("course_ids.hours", "course_ids.credits", "course_ids.weight")
+    @api.depends(
+        "course_ids", "course_ids.hours", "course_ids.credits", "course_ids.weight"
+    )
     def _compute_courses_total(self):
         for rec in self:
             total_hours = 0.0


### PR DESCRIPTION
The `_compute_courses_total` methods in `school.program`, `school.bloc`, and `school.course_group` were not being re-triggered when records were added or removed from their respective `One2many` and `Many2many` fields. This was due to a change in Odoo's behavior since version 14.0, where dependencies on related fields do not automatically recompute when the relation itself changes.

This commit fixes the issue by adding the `_ids` fields (`bloc_ids`, `course_group_ids`, and `course_ids`) to the `@api.depends` decorators of the respective `_compute_courses_total` methods. This ensures that the totals are correctly recalculated whenever the related records are modified.